### PR TITLE
Replace TestMotion with MoveAndSlide

### DIFF
--- a/client/ClientManager.cs
+++ b/client/ClientManager.cs
@@ -41,7 +41,8 @@ public partial class ClientManager : Node
 		_clock.ProcessTick();
 		int currentTick = _clock.GetCurrentTick();
 		int currentRemoteTick = _clock.GetCurrentRemoteTick();
-		CustomSpawner.LocalPlayer.ProcessTick(currentRemoteTick);
+		if (CustomSpawner.LocalPlayer != null)
+			CustomSpawner.LocalPlayer.ProcessTick(currentRemoteTick);
 		_snapshotInterpolator.ProcessTick(currentTick);
 	}
 

--- a/server/ServerManager.cs
+++ b/server/ServerManager.cs
@@ -9,7 +9,7 @@ public partial class ServerManager : Node
 	[Export] private int _port = 9999;
 
 	private SceneMultiplayer _multiplayer = new();
-	private Godot.Collections.Array<Godot.Node> entityArray;
+	private Godot.Collections.Array<Godot.Node> entityArray = new Godot.Collections.Array<Node>();
 	private ServerClock _serverClock;
 
 	private int _currentTick = 0;

--- a/server/ServerPlayer.cs
+++ b/server/ServerPlayer.cs
@@ -64,12 +64,11 @@ public partial class ServerPlayer : CharacterBody3D
 	private void AdvancePhysics(byte input)
 	{
 		this.Velocity = PlayerMovement.ComputeMotion(
-			this.GetRid(),
 			this.GlobalTransform,
 			this.Velocity,
 			PlayerMovement.InputToDirection(input));
 
-		Position += this.Velocity * PlayerMovement.FrameDelta;
+		MoveAndSlide();
 	}
 
 

--- a/shared/PlayerMovement.cs
+++ b/shared/PlayerMovement.cs
@@ -5,7 +5,7 @@ public static class PlayerMovement
 {
     public static readonly float FrameDelta = 1.0f / Engine.PhysicsTicksPerSecond;
 
-    public static Vector3 ComputeMotion(Rid rid, Transform3D from, Vector3 velocity, Vector2 input)
+    public static Vector3 ComputeMotion(Transform3D from, Vector3 velocity, Vector2 input)
     {
         Vector3 direction = new Vector3(input.X, 0, input.Y).Normalized();
 
@@ -17,19 +17,6 @@ public static class PlayerMovement
         else
         {
             velocity *= 0.99f;
-        }
-
-        PhysicsTestMotionParameters3D testParameters = new();
-        testParameters.From = from;
-        testParameters.Motion = velocity * FrameDelta;
-
-        PhysicsTestMotionResult3D collResult = new();
-
-        bool hasCollided = PhysicsServer3D.BodyTestMotion(rid, testParameters, collResult);
-
-        if (hasCollided)
-        {
-            velocity = velocity.Slide(collResult.GetCollisionNormal());
         }
 
         return velocity;


### PR DESCRIPTION
Replace TestMotion with MoveAndSlide
Fixed various errors.

Fixes https://github.com/grazianobolla/godot4-multiplayer-template/issues/8

The propose solution is 2 parts

1. "Inverting" the deviation check logic.
    - we now capture the clients state along side the input
    - using this we can now compare the incoming state with the captured state at the time of the tick
    - if a deviation is found we run the simulation starting from the incoming state using all inputs that haven't been processed
    - during simulation we also need to stop taking in new inputs on the client.
2. using move and slide
    - move and slide assumes physics delta
    - so we have to do some clever math to cancel it out while applying process delta and then the inverse after the call.

The need for 1. is due to the fact that running the simulation using move and slide actually moves the player. so to prevent constant simulations we need to only do so when a deviation is found first. otherwise we would need a "ghost" characterbody3d that we would constantly be moving and checking against. and can become quite complicated when things like state machines are introduced.